### PR TITLE
Fix license field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "commonjs",
   "devDependencies": {
     "electron": "^37.2.0"


### PR DESCRIPTION
## Summary
- set package.json `license` field to `MIT`

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865bce504908329bbdcf839daf38a42