### PR TITLE
Add macOS activate handler

### DIFF
--- a/main.js
+++ b/main.js
@@ -14,6 +14,12 @@ function createWindow() {
 
 app.whenReady().then(createWindow);
 
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createWindow();
+  }
+});
+
 app.on('window-all-closed', () => {
   if (process.platform !== 'darwin') {
     app.quit();


### PR DESCRIPTION
## Summary
- recreate the main window when the app is activated with no open windows

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6865bce711c48329b03583408d4d7856