### PR TITLE
Add default CSV auto-load

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -61,3 +61,27 @@ function updatePreview() {
 printBtn.addEventListener('click', () => {
   window.print();
 });
+
+// Automatically load the default employee CSV on launch
+const defaultCsvPath = path.join(__dirname, 'data', 'Employee.csv');
+const content = fs.readFileSync(defaultCsvPath, 'utf8');
+
+const raw = parse(content, { columns: true });
+employees = raw.map((record) => {
+  const cleaned = {};
+  for (const key in record) {
+    const cleanKey = key.trim().replace(/^\"|\"$/g, '');
+    cleaned[cleanKey] = record[key];
+  }
+  return cleaned;
+});
+
+recordSelector.innerHTML = '';
+employees.forEach((record, idx) => {
+  const opt = document.createElement('option');
+  opt.value = idx;
+  opt.innerText = `${record['Name']}`;
+  recordSelector.appendChild(opt);
+});
+
+updatePreview();


### PR DESCRIPTION
## Summary
- automatically load `data/Employee.csv` when the app starts
- keep the preview photo replacement logic and update preview when names are clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865c738d2948329a0387aff15fe1b12