### PR TITLE
Refactor employee loading and UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,8 +7,7 @@
 </head>
 <body>
   <h1>Electron Badge Generator</h1>
-  <input type="file" id="csvLoader" accept=".csv">
-  <select id="recordSelector"></select>
+  <div id="recordList"></div>
   <select id="templateSelector">
     <option value="templates/general.html">General</option>
   </select>

--- a/renderer.js
+++ b/renderer.js
@@ -4,49 +4,21 @@ const parse = require('csv-parse/lib/sync');
 
 let employees = [];
 
-const csvLoader = document.getElementById('csvLoader');
-const recordSelector = document.getElementById('recordSelector');
+const recordList = document.getElementById('recordList');
 const templateSelector = document.getElementById('templateSelector');
 const badgePreview = document.getElementById('badgePreview');
 const printBtn = document.getElementById('printBtn');
 
-csvLoader.addEventListener('change', (e) => {
-  const file = e.target.files[0];
-  if (!file) return;
+let currentIndex = 0;
+templateSelector.addEventListener('change', () => updatePreview(currentIndex));
 
-  const content = fs.readFileSync(file.path, 'utf8');
-  const raw = parse(content, { columns: true });
-  employees = raw.map((record) => {
-    const cleaned = {};
-    for (const key in record) {
-      const cleanKey = key.trim().replace(/^"|"$/g, '');
-      cleaned[cleanKey] = record[key];
-    }
-    return cleaned;
-  });
-  console.log('Cleaned employee fields:', Object.keys(employees[0]));
-
-  recordSelector.innerHTML = '';
-  employees.forEach((record, idx) => {
-    const opt = document.createElement('option');
-    opt.value = idx;
-    opt.innerText = `${record['Entry Number']} - ${record['Name']}`;
-    recordSelector.appendChild(opt);
-  });
-
-  updatePreview();
-});
-
-recordSelector.addEventListener('change', updatePreview);
-templateSelector.addEventListener('change', updatePreview);
-
-function updatePreview() {
-  const selected = recordSelector.value;
+function updatePreview(index) {
+  currentIndex = index;
   const templatePath = templateSelector.value;
-  if (!employees[selected]) return;
+  if (!employees[index]) return;
 
   let html = fs.readFileSync(templatePath, 'utf8');
-  const record = employees[selected];
+  const record = employees[index];
 
   Object.keys(record).forEach((field) => {
     const regex = new RegExp(`{{${field}}}`, 'g');
@@ -76,12 +48,14 @@ employees = raw.map((record) => {
   return cleaned;
 });
 
-recordSelector.innerHTML = '';
+recordList.innerHTML = '';
 employees.forEach((record, idx) => {
-  const opt = document.createElement('option');
-  opt.value = idx;
-  opt.innerText = `${record['Name']}`;
-  recordSelector.appendChild(opt);
+  const btn = document.createElement('button');
+  btn.innerText = record['Name'] || `Record ${idx + 1}`;
+  btn.onclick = () => updatePreview(idx);
+  recordList.appendChild(btn);
 });
 
-updatePreview();
+if (employees.length > 0) {
+  updatePreview(0);
+}


### PR DESCRIPTION
## Summary
- remove manual CSV loader and use default data/Employee.csv on startup
- replace dropdown selector with clickable buttons
- update preview logic to accept record index

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6865c7ba74ac8329a0426f36bf4167fa